### PR TITLE
Add WPML support

### DIFF
--- a/classes/wpbip-process.php
+++ b/classes/wpbip-process.php
@@ -46,15 +46,17 @@ if ( ! class_exists( 'Wpbip_Process' ) ) {
 					if ( ! is_wp_error( $result ) ) {
 						// Update the image meta
 						$meta = wp_get_attachment_metadata( $item['attachment_id'], true );
+						if( isset($meta) && is_array($meta) ){
 
-						$meta['sizes'][ $item['size_name'] ] = array(
-							'file'      => $result['file'],
-							'width'     => $result['width'],
-							'height'    => $result['height'],
-							'mime-type' => $result['mime-type'],
-						);
+							$meta['sizes'][ $item['size_name'] ] = array(
+								'file'      => $result['file'],
+								'width'     => $result['width'],
+								'height'    => $result['height'],
+								'mime-type' => $result['mime-type'],
+							);
 
-						wp_update_attachment_metadata( $item['attachment_id'], $meta );
+							wp_update_attachment_metadata( $item['attachment_id'], $meta );
+						}
 					} else {
 						$errored = true;
 					}


### PR DESCRIPTION
It looks like my code changes solve the [issue](https://github.com/darylldoyle/WP-Background-Image-Processing/issues/2) of not deleting the image files generated by WP-Background-Image-Processing if WPML is activated.

Can anyone confirm?